### PR TITLE
Adding support for some ES2015 features

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 var COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+var DEFAULT_PARAMS = /=[^,]+/mg;
+var FAT_ARROWS = /=>.*$/mg;
+
 function getParameterNames(fn) {
-  var code = fn.toString().replace(COMMENTS, '');
+  var code = fn.toString()
+    .replace(COMMENTS, '')
+    .replace(FAT_ARROWS, '')
+    .replace(DEFAULT_PARAMS, '');
+
   var result = code.slice(code.indexOf('(') + 1, code.indexOf(')'))
     .match(/([^\s,]+)/g);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -95,4 +95,28 @@ describe('function tests', function () {
 
     expect(arg(π9)).to.deep.equal(['ƒ', 'µ']);
   });
+
+  it('supports ES2015 fat arrow functions with parens', function() {
+    var f = '(a,b) => a + b'
+
+    expect(arg(f)).to.deep.equal(['a', 'b']);
+  })
+
+  it('supports ES2015 fat arrow functions without parens', function() {
+    var f = 'a => a + 2'
+    expect(arg(f)).to.deep.equal(['a']);
+  })
+
+  it('ignores ES2015 default params', function() {
+    // default params supported in node.js ES6
+    var f11 = '(a, b = 20) => a + b'
+
+    expect(arg(f11)).to.deep.equal(['a', 'b']);
+  })
+
+  it('supports function created using the Function constructor', function() {
+    var f = new Function('a', 'b', 'return a + b');
+
+    expect(arg(f)).to.deep.equal(['a', 'b']);
+  })
 });


### PR DESCRIPTION
It now supports arrow functions and default parameters.

For example:

``` js
a => a * 2
(a, b=20) => a + b
function (a, b=20) { return a + b; }
```

I've added unit tests for these. I made the tests pass in stringified versions of the functions instead of the functions directly so that Node.js >= 0.4.0 could run the tests without breaking.
