### PR TITLE
Fixed the two known issues that are present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,20 @@
 var COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var DEFAULT_PARAMS = /=[^,]+/mg;
 var FAT_ARROWS = /=>.*$/mg;
+var SPACES = /\s/mg;
+var BEFORE_OPENING_PAREN = /^[^(]*\(/mg;
+var AFTER_CLOSING_PAREN = /^([^)]*)\).*$/mg;
 
 function getParameterNames(fn) {
   var code = fn.toString()
+    .replace(SPACES, '')
     .replace(COMMENTS, '')
     .replace(FAT_ARROWS, '')
-    .replace(DEFAULT_PARAMS, '');
+    .replace(DEFAULT_PARAMS, '')
+    .replace(BEFORE_OPENING_PAREN, '')
+    .replace(AFTER_CLOSING_PAREN, '$1');
 
-  var result = code.slice(code.indexOf('(') + 1, code.indexOf(')'))
-    .match(/([^\s,]+)/g);
-
-  return result === null
-    ? []
-    : result;
+  return code.split(',')
 }
 
 module.exports = getParameterNames;

--- a/test/tests.js
+++ b/test/tests.js
@@ -107,6 +107,32 @@ describe('function tests', function () {
     expect(arg(f)).to.deep.equal(['a']);
   })
 
+  it('supports ES2015 fat arrow function without parens test1.', function() {
+    var f = c => {
+      var test2 = c.resolve();
+      return new Test3(test2);
+    };
+
+    expect(arg(f)).to.deep.equal(['c']);
+  })
+
+  it('supports ES2015 fat arrow function without parens test2.', function() {
+    var f = a => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(a * 2), 500);
+      });
+    }
+
+    expect(arg(f)).to.deep.equal(['a']);
+  });
+
+  it('supports ES2015 fat arrow function without parens test3.', function() {
+    var f = items => items.map(
+      i => t.foo);
+
+    expect(arg(f)).to.deep.equal(['items']);
+  })
+
   it('ignores ES2015 default params', function() {
     // default params supported in node.js ES6
     var f11 = '(a, b = 20) => a + b'
@@ -120,3 +146,4 @@ describe('function tests', function () {
     expect(arg(f)).to.deep.equal(['a', 'b']);
   })
 });
+


### PR DESCRIPTION
Both issues are related to single-parameter arrow functions that do not wrap parameters in arrows.  All original tests are passing, and I added tests to cover the two reported issues and the one pull request.  I tried to match your coding conventions.
