### PR TITLE
Fix for single- and no-argument arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,20 @@
 var COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var DEFAULT_PARAMS = /=[^,]+/mg;
 var FAT_ARROWS = /=>.*$/mg;
+var SPACES = /\s/mg;
+var BEFORE_OPENING_PAREN = /^[^(]*\(/mg;
+var AFTER_CLOSING_PAREN = /^([^)]*)\).*$/mg;
 
 function getParameterNames(fn) {
   var code = fn.toString()
+    .replace(SPACES, '')
     .replace(COMMENTS, '')
     .replace(FAT_ARROWS, '')
-    .replace(DEFAULT_PARAMS, '');
+    .replace(DEFAULT_PARAMS, '')
+    .replace(BEFORE_OPENING_PAREN, '')
+    .replace(AFTER_CLOSING_PAREN, '$1');
 
-  var result = code.slice(code.indexOf('(') + 1, code.indexOf(')'))
-    .match(/([^\s,]+)/g);
-
-  return result === null
-    ? []
-    : result;
+  return code.split(',')
 }
 
 module.exports = getParameterNames;

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function getParameterNames(fn) {
     .replace(BEFORE_OPENING_PAREN, '')
     .replace(AFTER_CLOSING_PAREN, '$1');
 
-  return code.split(',');
+  return code ? code.split(',') : [];
 }
 
 module.exports = getParameterNames;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 var COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var DEFAULT_PARAMS = /=[^,]+/mg;
-var FAT_ARROWS = /=>.*$/mg;
+var FAT_ARROWS = /=>.*/mg;
+var NEWLINES = '\n'
 
 function getParameterNames(fn) {
   var code = fn.toString()
     .replace(COMMENTS, '')
+    .replace(NEWLINES, '')
     .replace(FAT_ARROWS, '')
     .replace(DEFAULT_PARAMS, '');
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function getParameterNames(fn) {
     .replace(BEFORE_OPENING_PAREN, '')
     .replace(AFTER_CLOSING_PAREN, '$1');
 
-  return code.split(',')
+  return code.split(',');
 }
 
 module.exports = getParameterNames;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "get-parameter-names",
+  "name": "@avejidah/get-parameter-names",
   "author": "Josh Perez <josh@goatslacker.com>",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Retrieves parameter names from a function",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@avejidah/get-parameter-names",
   "author": "Josh Perez <josh@goatslacker.com>",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Retrieves parameter names from a function",
   "license": "MIT",
   "repository": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -96,27 +96,32 @@ describe('function tests', function () {
     expect(arg(π9)).to.deep.equal(['ƒ', 'µ']);
   });
 
-  it('supports ES2015 fat arrow functions with parens', function() {
+  it('supports ES2015 fat arrow functions with parens', function () {
     var f = '(a,b) => a + b'
 
     expect(arg(f)).to.deep.equal(['a', 'b']);
-  })
+  });
 
-  it('supports ES2015 fat arrow functions without parens', function() {
+  it('supports ES2015 fat arrow functions without parens', function () {
     var f = 'a => a + 2'
     expect(arg(f)).to.deep.equal(['a']);
-  })
+  });
 
-  it('ignores ES2015 default params', function() {
+  it('supports ES2015 fat arrow functions without parens and new line no parens fat arrow function', function () {
+    var f = 'a => a.map(\n b => b)';
+    expect(arg(f)).to.deep.equal(['a']);
+  });
+
+  it('ignores ES2015 default params', function () {
     // default params supported in node.js ES6
     var f11 = '(a, b = 20) => a + b'
 
     expect(arg(f11)).to.deep.equal(['a', 'b']);
-  })
+  });
 
-  it('supports function created using the Function constructor', function() {
+  it('supports function created using the Function constructor', function () {
     var f = new Function('a', 'b', 'return a + b');
 
     expect(arg(f)).to.deep.equal(['a', 'b']);
-  })
+  });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -107,6 +107,32 @@ describe('function tests', function () {
     expect(arg(f)).to.deep.equal(['a']);
   })
 
+  it('supports ES2015 fat arrow function without parens test1.', function() {
+    var f = c => {
+      var test2 = c.resolve();
+      return new Test3(test2);
+    };
+
+    expect(arg(f)).to.deep.equal(['c']);
+  })
+
+  it('supports ES2015 fat arrow function without parens test2.', function() {
+    var f = a => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(a * 2), 500);
+      });
+    }
+
+    expect(arg(f)).to.deep.equal(['a']);
+  });
+
+  it('supports ES2015 fat arrow function without parens test3.', function() {
+    var f = items => items.map(
+      i => t.foo);
+
+    expect(arg(f)).to.deep.equal(['items']);
+  })
+
   it('ignores ES2015 default params', function() {
     // default params supported in node.js ES6
     var f11 = '(a, b = 20) => a + b'
@@ -120,3 +146,4 @@ describe('function tests', function () {
     expect(arg(f)).to.deep.equal(['a', 'b']);
   })
 });
+

--- a/test/tests.js
+++ b/test/tests.js
@@ -132,8 +132,8 @@ describe('function tests', function () {
   });
 
   it('supports ES2015 fat arrow function without parens test3.', function() {
-    var f = items => items.map(
-      i => t.foo);
+    var f = 'items => items.map(\n'
+      + '  i => t.foo)';
 
     expect(arg(f)).to.deep.equal(['items']);
   })

--- a/test/tests.js
+++ b/test/tests.js
@@ -96,6 +96,11 @@ describe('function tests', function () {
     expect(arg(π9)).to.deep.equal(['ƒ', 'µ']);
   });
 
+  it('test9', function() {
+    function test9() {}
+    expect(arg(test9)).to.deep.equal([]);
+  });
+
   it('supports ES2015 fat arrow functions with parens', function () {
     var f = '(a,b) => a + b';
 
@@ -136,6 +141,12 @@ describe('function tests', function () {
       + '  i => t.foo)';
 
     expect(arg(f)).to.deep.equal(['items']);
+  });
+
+  it('supports ES2015 fat arrow function without arguments.', function() {
+    var f = '() => 1';
+
+    expect(arg(f)).to.deep.equal([]);
   });
 
   it('ignores ES2015 default params', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 describe('function tests', function () {
   it('test1', function () {
     function /* (no parenthesis like this) */ test1(a, b, c){
-      return true
+      return true;
     }
 
     expect(arg(test1)).to.deep.equal(['a', 'b', 'c']);
@@ -12,7 +12,7 @@ describe('function tests', function () {
 
   it('test2', function () {
     function test2(a, b, c) /*(why do people do this??)*/{
-      return true
+      return true;
     }
 
     expect(arg(test2)).to.deep.equal(['a', 'b', 'c']);
@@ -20,7 +20,7 @@ describe('function tests', function () {
 
   it('test3', function () {
     function test3(a, /* (jewiofewjf,wo, ewoi, werp)*/ b, c) {
-      return true
+      return true;
     }
 
     expect(arg(test3)).to.deep.equal(['a', 'b', 'c']);
@@ -29,7 +29,7 @@ describe('function tests', function () {
   it('test4', function () {
     function test4(a/* a*/, /* b */b, /*c*/c,d/*d*/) {
       return function (one, two, three) {
-      }
+      };
     }
 
     expect(arg(test4)).to.deep.equal(['a', 'b', 'c', 'd']);
@@ -48,7 +48,7 @@ describe('function tests', function () {
   });
 
   it('test6', function () {
-    function test6(a) { return function f6(a, b) { } }
+    function test6(a) { return function f6(a, b) { }; }
 
     expect(arg(test6)).to.deep.equal(['a']);
   });
@@ -78,7 +78,7 @@ describe('function tests', function () {
        return false;
      }
      */
-    a,b,c) { return true }
+    a,b,c) { return true; }
 
     expect(arg(test7)).to.deep.equal(['a', 'b', 'c']);
   });
@@ -91,19 +91,19 @@ describe('function tests', function () {
   });
 
   it('test9', function () {
-    function π9(ƒ, µ) { (a + 2 + b + 2 + c) }
+    function π9(ƒ, µ) { (a + 2 + b + 2 + c); }
 
     expect(arg(π9)).to.deep.equal(['ƒ', 'µ']);
   });
 
   it('supports ES2015 fat arrow functions with parens', function () {
-    var f = '(a,b) => a + b'
+    var f = '(a,b) => a + b';
 
     expect(arg(f)).to.deep.equal(['a', 'b']);
   });
 
   it('supports ES2015 fat arrow functions without parens', function () {
-    var f = 'a => a + 2'
+    var f = 'a => a + 2';
     expect(arg(f)).to.deep.equal(['a']);
   });
 
@@ -119,14 +119,14 @@ describe('function tests', function () {
       +'}';
 
     expect(arg(f)).to.deep.equal(['c']);
-  })
+  });
 
   it('supports ES2015 fat arrow function without parens test2.', function() {
     var f = 'a => {\n'
       + '  return new Promise((resolve, reject) => {\n'
       + '    setTimeout(() => resolve(a * 2), 500);\n'
       + '  })'
-      + '}'
+      + '}';
 
     expect(arg(f)).to.deep.equal(['a']);
   });
@@ -136,11 +136,11 @@ describe('function tests', function () {
       + '  i => t.foo)';
 
     expect(arg(f)).to.deep.equal(['items']);
-  })
+  });
 
   it('ignores ES2015 default params', function() {
     // default params supported in node.js ES6
-    var f11 = '(a, b = 20) => a + b'
+    var f11 = '(a, b = 20) => a + b';
 
     expect(arg(f11)).to.deep.equal(['a', 'b']);
   });


### PR DESCRIPTION
Covers the two open issues, as well is PR7.  I've published my fork as a scoped module in npm: npm install @avejidah/get-parameter-names
