### PR TITLE
fix bug when function like as 'f(id = 1)'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
-var DEFAULT_PARAMS = /=[^,]+/mg;
+var DEFAULT_PARAMS = /=[^(\),)]+/mg;
 var FAT_ARROWS = /=>.*$/mg;
 
 function getParameterNames(fn) {


### PR DESCRIPTION
```
function f(id = 1){
    id = 'a,b';
}

getParameterNames(f); // => [ 'id', 'b\';' ]
```